### PR TITLE
Fix minor bug in KF matrix sizes check

### DIFF
--- a/filterpy/kalman/kalman_filter.py
+++ b/filterpy/kalman/kalman_filter.py
@@ -321,7 +321,7 @@ class KalmanFilter(object):
                "Shape of P must be ({},{}), but is {}".format(
                self.dim_x, self.dim_x, P.shape)
 
-        assert self._F.shape == (self.dim_x, self.dim_x), \
+        assert F.shape == (self.dim_x, self.dim_x), \
                "Shape of F must be ({},{}), but is {}".format(
                self.dim_x, self.dim_x, F.shape)
 


### PR DESCRIPTION
When the `F` matrix is passed to `KalmanFilter.test_matrix_dimension`, it should be used in the checks instead of `KalmanFilter._F`.