### PR TITLE
Fix doc block for Kalman filter measurement matrix

### DIFF
--- a/filterpy/kalman/kalman_filter.py
+++ b/filterpy/kalman/kalman_filter.py
@@ -149,7 +149,7 @@ class KalmanFilter(object):
     F : numpy.array()
         State Transition matrix
 
-    H : numpy.array(dim_x, dim_x)
+    H : numpy.array(dim_z, dim_x)
         Measurement function
 
 


### PR DESCRIPTION
Measurement matrix dimensions in Kalman filter class doc block is misleading and should be changed.