### PR TITLE
Documentation typo: dim_z mistaken for dim_x

### DIFF
--- a/docs/kalman/KalmanFilter.rst
+++ b/docs/kalman/KalmanFilter.rst
@@ -43,7 +43,7 @@ P : ndarray (dim_x, dim_x), default eye(dim_x)
 Q : ndarray (dim_x, dim_x), default eye(dim_x)
     Process uncertainty/noise
 
-R : ndarray (dim_z, dim_z), default eye(dim_x)
+R : ndarray (dim_z, dim_z), default eye(dim_z)
     measurement uncertainty/noise
 
 H : ndarray (dim_z, dim_x)


### PR DESCRIPTION
Measurement uncertainty deals with measurement matrix cardinality (dim_z) rather than state matrix (dim_x). Verified that code runs correctly with `eye(dim_z)`, but produces errors with `eye(dim_x)`.