### PR TITLE
Corrected shape of self.sigmas_h

### DIFF
--- a/filterpy/kalman/UKF.py
+++ b/filterpy/kalman/UKF.py
@@ -444,7 +444,7 @@ class UnscentedKalmanFilter(object):
         for s in self.sigmas_f:
             sigmas_h.append(hx(s, **hx_args))
 
-        self.sigmas_h = np.atleast_2d(sigmas_h)
+        self.sigmas_h = np.atleast_2d(sigmas_h).T
 
         # mean and covariance of prediction passed through unscented transform
         zp, self.S = UT(self.sigmas_h, self.Wm, self.Wc, R, self.z_mean, self.residual_z)


### PR DESCRIPTION
Fixed again bug #129

>   File "g:\proj\python\filterpy\filterpy\kalman\UKF.py", line 605, in batch_filter
>     self.update(z, r, UT=UT)
>   File "g:\proj\python\filterpy\filterpy\kalman\UKF.py", line 450, in update
>     zp, self.S = UT(self.sigmas_h, self.Wm, self.Wc, R, self.z_mean, self.residual_z)
>   File "g:\proj\python\filterpy\filterpy\kalman\unscented_transform.py", line 104, in unscented_transform
>     x = np.dot(Wm, sigmas)    # dot = \Sigma^n_1 (W[k]*Xi[k])
> ValueError: shapes (5,) and (1,5) not aligned: 5 (dim 0) != 1 (dim 0)
