### PR TITLE
Correct docstring about save_current parameter

### DIFF
--- a/filterpy/common/helpers.py
+++ b/filterpy/common/helpers.py
@@ -56,7 +56,7 @@ class Saver(object):
         any object with a __dict__ attribute, but intended to be one of the
         filtering classes
 
-    save_current : bool, default=True
+    save_current : bool, default=False
         save the current state of `kf` when the object is created;
 
     skip_private: bool, default=False


### PR DESCRIPTION
Edit the docstring about 'save_current'.
Change its value on docstring from 'True' to 'False'.

Reference to docstring:
[save_current docstring](https://github.com/rlabbe/filterpy/blob/9b9dcda99d262b6ca71e3130fc21077808e61275/filterpy/common/helpers.py#L59)

Reference to code:
[save_current code](https://github.com/rlabbe/filterpy/blob/9b9dcda99d262b6ca71e3130fc21077808e61275/filterpy/common/helpers.py#L96)

Address issue #170.