### PR TITLE
change comparison to <= to avoid index error due to roundoff error

### DIFF
--- a/filterpy/monte_carlo/resampling.py
+++ b/filterpy/monte_carlo/resampling.py
@@ -106,7 +106,7 @@ def stratified_resample(weights):
     cumulative_sum = np.cumsum(weights)
     i, j = 0, 0
     while i < N:
-        if positions[i] < cumulative_sum[j]:
+        if positions[i] <= cumulative_sum[j]:
             indexes[i] = j
             i += 1
         else:
@@ -142,7 +142,7 @@ def systematic_resample(weights):
     cumulative_sum = np.cumsum(weights)
     i, j = 0, 0
     while i < N:
-        if positions[i] < cumulative_sum[j]:
+        if positions[i] <= cumulative_sum[j]:
             indexes[i] = j
             i += 1
         else:


### PR DESCRIPTION
The last element of 'position' can become equal to 1.0 due to roundoff
error, in case the random number drawn is very close to 1. In this
case, the index into 'cumulative_sum' will exceed N (before this commit).