### PR TITLE
Fix dimensionality mismatch in correlated kf update

### DIFF
--- a/filterpy/kalman/kalman_filter.py
+++ b/filterpy/kalman/kalman_filter.py
@@ -410,7 +410,7 @@ class KalmanFilter(object):
         self.H = zeros((dim_z, dim_x))    # Measurement function
         self.R = eye(dim_z)               # state uncertainty
         self._alpha_sq = 1.               # fading memory control
-        self.M = np.zeros((dim_z, dim_z)) # process-measurement cross correlation
+        self.M = np.zeros((dim_x, dim_z)) # process-measurement cross correlation
         self.z = np.array([[None]*self.dim_z]).T
 
         # gain and residual are computed during the innovation step. We
@@ -676,6 +676,8 @@ class KalmanFilter(object):
         process noise and measurement noise are correlated as defined in
         the `self.M` matrix.
 
+        A partial derivation can be found in [1]
+
         If z is None, nothing is changed.
 
         Parameters
@@ -691,6 +693,12 @@ class KalmanFilter(object):
         H : np.array,  or None
             Optionally provide H to override the measurement function for this
             one call, otherwise  self.H will be used.
+
+        References
+        ----------
+
+        .. [1] Bulut, Y. (2011). Applied Kalman filter theory (Doctoral dissertation, Northeastern University).
+               http://people.duke.edu/~hpgavin/SystemID/References/Balut-KalmanFilter-PhD-NEU-2011.pdf
         """
 
         # set to None to force recompute

--- a/filterpy/kalman/tests/test_kf.py
+++ b/filterpy/kalman/tests/test_kf.py
@@ -627,6 +627,14 @@ def test_z_checks():
     kf.update(np.array([[3, 4]]))
     kf.update(np.array([[3, 4]]).T)
 
+def test_update_correlated():
+    f = const_vel_filter(1.0, x0=2, R_std=1., Q_var=5.1)
+    f.M = np.array([[1], [0]])
+
+    for i in range(10):
+        f.predict()
+        f.update_correlated(3.)
+
 
 if __name__ == "__main__":
     DO_PLOT = True


### PR DESCRIPTION
The correlation matrix between the process and measurement noise has to
have the dimension dim_x x dim_z, instead of being square. I took [1] and [2] as sources for the correction.

This commit also adds a test for the correlated update.

Solves issue #187.

[1] http://kom.aau.dk/~borre/kalman/lecture7/lec7.pdf
[2] http://people.duke.edu/~hpgavin/SystemID/References/Balut-KalmanFilter-PhD-NEU-2011.pdf