### PR TITLE
Fix test by relaxing near_eq (from 1e-18 to 1e-17)

### DIFF
--- a/filterpy/common/tests/test_discretization.py
+++ b/filterpy/common/tests/test_discretization.py
@@ -23,7 +23,7 @@ from filterpy.common import (linear_ode_discretation, Q_discrete_white_noise,
 from numpy import array
 
 def near_eq(x,y):
-    return abs(x-y) < 1.e-18
+    return abs(x-y) < 1.e-17
 
 
 def test_kinematic():


### PR DESCRIPTION
In Python 3.8.6 at Ubuntu, `test_linear_ode` from `filterpy/common/tests/test_discretization.py` fails with

```
>       assert near_eq(Q[0,4], (1./6)*(dt**3)*q)
E       assert False
E        +  where False = near_eq(0.004166666666666665, (((1.0 / 6) * (0.5 ** 3)) * 0.2))
```

I'm not sure why `near_eq` needs this tight bounds, even `1e-15` could be good enough.