### PR TITLE
Fix misleading comment

### DIFF
--- a/filterpy/kalman/kalman_filter.py
+++ b/filterpy/kalman/kalman_filter.py
@@ -406,8 +406,8 @@ class KalmanFilter(object):
         self.Q = eye(dim_x)               # process uncertainty
         self.B = None                     # control transition matrix
         self.F = eye(dim_x)               # state transition matrix
-        self.H = zeros((dim_z, dim_x))    # Measurement function
-        self.R = eye(dim_z)               # state uncertainty
+        self.H = zeros((dim_z, dim_x))    # measurement function
+        self.R = eye(dim_z)               # measurement uncertainty
         self._alpha_sq = 1.               # fading memory control
         self.M = np.zeros((dim_x, dim_z)) # process-measurement cross correlation
         self.z = np.array([[None]*self.dim_z]).T


### PR DESCRIPTION
Hi!

I think this comment says "state uncertainty" but should say "measurement uncertainty" as the matrix has the dimension of the measurement.

It matters because when you "go to definition" in an IDE, it sends you here.