### PR TITLE
residual_of() does not reshahape z

### DIFF
--- a/filterpy/kalman/kalman_filter.py
+++ b/filterpy/kalman/kalman_filter.py
@@ -1105,6 +1105,7 @@ class KalmanFilter(object):
         Returns the residual for the given measurement (z). Does not alter
         the state of the filter.
         """
+        z = reshape_z(z, self.dim_z, self.x.ndim)
         return z - dot(self.H, self.x_prior)
 
     def measurement_of_state(self, x):


### PR DESCRIPTION
Other update functions reshape z to work correctly, but not here.
If len(z) == 2 the residual_of() will return a 2x2 matrix.

```
In [173]: z
Out[173]: array([-1.36612672e-02,  1.01328912e+03])

In [174]: my_filter.residual_of(z)
Out[174]: 
array([[-1.36612672e-02,  1.01328912e+03],
       [-1.01330278e+03,  0.00000000e+00]])

In [175]: my_filter.residual_of(filterpy.common.reshape_z(z, my_filter.dim_z, my_filter.x.ndim))
Out[175]: 
array([[-0.01366127],
       [ 0.        ]])
```