### PR TITLE
Erroneous reset of state variables in mmae

### DIFF
--- a/filterpy/kalman/mmae.py
+++ b/filterpy/kalman/mmae.py
@@ -199,7 +199,6 @@ class MMAEFilterBank(object):
         else:
             self.x = np.zeros((self.dim_x, 1))
             for f, p in zip(self.filters, self.p):
-                self.x = np.zeros((self.dim_x, 1))
                 self.x += np.dot(f.x, p)
 
         for x, f, p in zip(self.x, self.filters, self.p):


### PR DESCRIPTION
The additional reset causes all but the last of the filters to be ignored when accumulating the weighted state variables.