### PR TITLE
Fixing square root kalman (K, S, and off-diagonal elements of P)

### DIFF
--- a/filterpy/kalman/square_root.py
+++ b/filterpy/kalman/square_root.py
@@ -274,7 +274,7 @@ class SquareRootKalmanFilter(object):
     @property
     def Q(self):
         """ Process uncertainty"""
-        return dot(self._Q1_2.T, self._Q1_2)
+        return dot(self._Q1_2, self._Q1_2.T)
 
     @property
     def Q1_2(self):
@@ -290,17 +290,17 @@ class SquareRootKalmanFilter(object):
     @property
     def P(self):
         """ covariance matrix"""
-        return dot(self._P1_2.T, self._P1_2)
+        return dot(self._P1_2, self._P1_2.T)
 
     @property
     def P_prior(self):
         """ covariance matrix of the prior"""
-        return dot(self._P1_2_prior.T, self._P1_2_prior)
+        return dot(self._P1_2_prior, self._P1_2_prior.T)
 
     @property
     def P_post(self):
         """ covariance matrix of the posterior"""
-        return dot(self._P1_2_prior.T, self._P1_2_prior)
+        return dot(self._P1_2_prior, self._P1_2_prior.T)
 
     @property
     def P1_2(self):
@@ -316,7 +316,7 @@ class SquareRootKalmanFilter(object):
     @property
     def R(self):
         """ measurement uncertainty"""
-        return dot(self._R1_2.T, self._R1_2)
+        return dot(self._R1_2, self._R1_2.T)
 
     @property
     def R1_2(self):

--- a/filterpy/kalman/square_root.py
+++ b/filterpy/kalman/square_root.py
@@ -334,6 +334,11 @@ class SquareRootKalmanFilter(object):
         """ system uncertainty (P projected to measurement space) """
         return dot(self.S1_2, self.S1_2.T)
 
+    @property
+    def SI(self):
+        """ inverse system uncertainty (P projected to measurement space) """
+        return dot(self.SI1_2.T, self.SI1_2)
+
     def __repr__(self):
         return '\n'.join([
             'SquareRootKalmanFilter object',
@@ -349,6 +354,7 @@ class SquareRootKalmanFilter(object):
             pretty_str('K', self.K),
             pretty_str('y', self.y),
             pretty_str('S', self.S),
+            pretty_str('SI', self.SI),
             pretty_str('M', self.M),
             pretty_str('B', self.B),
             ])

--- a/filterpy/kalman/tests/test_sqrtkf.py
+++ b/filterpy/kalman/tests/test_sqrtkf.py
@@ -93,7 +93,7 @@ def test_noisy_1d():
 
     for i in range(f.P.shape[0]):
         for j in range(f.P.shape[1]):
-            assert abs(f.P[i,j] - fsq.P[i,j]) < 0.01
+            assert abs(f.P[i,j] - fsq.P[i,j]) < 1e-6
 
 
     # now do a batch run with the stored z values so we can test that

--- a/filterpy/kalman/tests/test_sqrtkf.py
+++ b/filterpy/kalman/tests/test_sqrtkf.py
@@ -82,7 +82,8 @@ def test_noisy_1d():
     s.to_array()
 
     for i in range(f.P.shape[0]):
-        assert abs(f.P[i,i] - fsq.P[i,i]) < 0.01
+        for j in range(f.P.shape[1]):
+            assert abs(f.P[i,j] - fsq.P[i,j]) < 0.01
 
 
     # now do a batch run with the stored z values so we can test that

--- a/filterpy/kalman/tests/test_sqrtkf.py
+++ b/filterpy/kalman/tests/test_sqrtkf.py
@@ -75,6 +75,13 @@ def test_noisy_1d():
         assert abs(f.x[0,0] - fsq.x[0,0]) < 1.e-12
         assert abs(f.x[1,0] - fsq.x[1,0]) < 1.e-12
 
+        S_from_sqrt = fsq.S
+        SI_from_sqrt = fsq.SI
+        for i in range(f.S.shape[0]):
+            for j in range(f.S.shape[1]):
+                assert abs(f.S[i,j] - S_from_sqrt[i,j]) < 1e-6
+                assert abs(f.SI[i,j] - SI_from_sqrt[i,j]) < 1e-6
+
         # save data
         results.append (f.x[0,0])
         measurements.append(z)

--- a/filterpy/kalman/tests/test_sqrtkf.py
+++ b/filterpy/kalman/tests/test_sqrtkf.py
@@ -25,7 +25,7 @@ from filterpy.kalman import SquareRootKalmanFilter, KalmanFilter
 
 DO_PLOT = False
 def test_noisy_1d():
-    f = KalmanFilter (dim_x=2, dim_z=1)
+    f = KalmanFilter (dim_x=2, dim_z=2)
 
     f.x = np.array([[2.],
                     [0.]])       # initial state (location and velocity)
@@ -33,12 +33,13 @@ def test_noisy_1d():
     f.F = np.array([[1.,1.],
                     [0.,1.]])    # state transition matrix
 
-    f.H = np.array([[1.,0.]])    # Measurement function
+    f.H = np.array([[1.,0.],
+                    [0.,1.]])    # Measurement function
     f.P *= 1000.                  # covariance matrix
     f.R *= 5                       # state uncertainty
     f.Q *= 0.0001                 # process uncertainty
 
-    fsq = SquareRootKalmanFilter (dim_x=2, dim_z=1)
+    fsq = SquareRootKalmanFilter (dim_x=2, dim_z=2)
 
     fsq.x = np.array([[2.],
                       [0.]])     # initial state (location and velocity)
@@ -46,7 +47,8 @@ def test_noisy_1d():
     fsq.F = np.array([[1.,1.],
                       [0.,1.]])  # state transition matrix
 
-    fsq.H = np.array([[1.,0.]])  # Measurement function
+    fsq.H = np.array([[1.,0.],
+                      [0.,1.]])  # Measurement function
     fsq.P = np.eye(2) * 1000.    # covariance matrix
     fsq.R *= 5                    # state uncertainty
     fsq.Q *= 0.0001               # process uncertainty
@@ -61,8 +63,9 @@ def test_noisy_1d():
     zs = []
     s = Saver(fsq)
     for t in range (100):
-        # create measurement = t plus white noise
-        z = t + random.randn()*20
+        # create measurement = t plus white noise for position and 1 +
+        # white noise for velocity
+        z = np.array([[t], [1.]]) + random.randn(2, 1)*20
         zs.append(z)
 
         # perform kalman filtering


### PR DESCRIPTION
I was trying to work through the math used in the square root kalman filter to make sure I understood it while comparing to various references such as BDO Anderson and JB Moore. Optimal filtering. Prentice-Hall (1979) and found a couple issues in the update method.

* The QR decomposition of M was stored in S, which is clearly not right since that is a (dim_x + dim_z, dim_x + dim_z) matrix when S should be (dim_z, dim_z). Instead, the transpose of sqrt S is in the top-left corner of the result.
* K was set to the top-right corner of the QR decomposition result, even though that still needs to be right multiplied by sqrt S.
* P, Q, and R were computed by multiplying their square root and its transpose int he wrong order, which could be seen by the off-diagonal elements of P not matching up with the standard kalman filter.

To fix this, I did the following

* Stored the QR decomposition of M in a temporary array
* Extract sqrt S from the QR decomposition
* Compute the inverse of sqrt S and store it
* Compute the K from the top-right corner of the QR decomposition result and the inverse of sqrt S
* Added a get property to compute S from sqrt S.
* Changed the order of multiplications for get properties of P, Q, and R.

I also went ahead and

* Added a get property for SI
* Made the test for the square root filter check all elements of P and with a smaller tolerance
* Made the test for the square root filter check all elements of S and SI against the non-sqrt filter
* Increased z_dim to 2 for the test for the square root filter to better catch any future errors in S and SI (many errors would survive scrutiny for 1x1 matrices that wouldn't for 2x2).