### PR TITLE
Generalized sigma-points

### DIFF
--- a/filterpy/kalman/sigma_points.py
+++ b/filterpy/kalman/sigma_points.py
@@ -635,7 +635,7 @@ class EbeigbeSigmaPoints(object):
             sigmas[i+n] = x + self.s[i+1]*np.sqrt(P)
         
         if self.positively_constrained:
-            self._redefine_scale_param(sigmas, x, P)
+            self._redefine_scale_param(sigmas)
             self._compute_weights(compute_free_parameter=False)
             
             sigmas[0]   = x

--- a/filterpy/kalman/sigma_points.py
+++ b/filterpy/kalman/sigma_points.py
@@ -534,68 +534,74 @@ class SimplexSigmaPoints(object):
             ])
 
 class EbeigbeSigmaPoints(object):
-    '''
-    '''
-    def __init__(self, n, positively_constrained=False, k=0.9):
+    def __init__(self, n, P, S, K, positively_constrained=False, k=None, x=None):
         self.n = n
+        
+        self.x = x
+        self.P = P
+        self.S = S
+        self.K = K
+        
         self.k = k
         self.positively_constrained = positively_constrained
         
-        # scaling parameter inicialization
-        self.s = np.zeros(2*n+1)
+        self.s = np.zeros(2*self.n+1)
+        
+        self._compute_weights()
         
     def num_sigmas(self):
         return 2*self.n + 1
     
-    def sigma_points(self, x, P, S, K):
+    def sigma_points(self, x, P):
+              
+        n = self.n
         
         for i in range(1, self.n+1):
-            std = np.sqrt(P)
-            
-            # standarized values        
-            S_ = S/std**3.0
-            K_ = K/std**4.0
-            
-            # free parameter
-            self.s[i] = 0.5*(-S_ + np.sqrt(4*K_ - 3*S_**2.0))
-                  
-            self._compute_weights(i, S_)
-            
-            sigmas = self._compute_sigmas(i, x, P)
+            sigmas = np.zeros(2*n+1)
+        
+            sigmas[0]   = x
+            sigmas[i]   = x - self.s[i  ]*np.sqrt(P)
+            sigmas[i+n] = x + self.s[i+1]*np.sqrt(P)
         
         if self.positively_constrained:
             self._redefine_scale_param(sigmas, x, P)
-            self._compute_weights(i, S_)
-            sigmas = self._compute_sigmas(i, x, P)
+            self._compute_weights(compute_free_parameter=False)
+            
+            sigmas[0]   = x
+            sigmas[i]   = x - self.s[i  ]*np.sqrt(P)
+            sigmas[i+n] = x + self.s[i+1]*np.sqrt(P)
         
         return sigmas
     
-    def _compute_weights(self, i, S_):
+    def _compute_weights(self, compute_free_parameter=True):
+        
         n = self.n
-        w = np.zeros(2*n+1)
-        self.s[i+n] = self.s[i] + S_
-        w[i+n] = 1.0/(self.s[i+n]*(self.s[i] + self.s[i+n]))
-        w[i] = self.s[i+n]/self.s[i]*w[i+n]
-        w[0] = 1 - np.sum(w)
+        
+        for i in range(1, self.n+1):
+            std = np.sqrt(self.P)
+            
+            # standarized values        
+            S_ = self.S/std**3.0
+            K_ = self.K/std**4.0
+            
+            # free parameter
+            if compute_free_parameter:
+                self.s[i] = 0.5*(-S_ + np.sqrt(4*K_ - 3*S_**2.0))
+            
+            # weights
+            w = np.zeros(2*n+1)
+            self.s[i+n] = self.s[i] + S_
+            w[i+n] = 1.0/(self.s[i+n]*(self.s[i] + self.s[i+n]))
+            w[i] = self.s[i+n]/self.s[i]*w[i+n]
+            w[0] = 1 - np.sum(w)
+        
         self.Wm = w
         self.Wc = w
         
-    def _compute_sigmas(self, i, x, P):
-        """ Number of sigma points for each variable in the state x"""
-        n = self.n
-        sigmas = np.zeros(2*n+1)
-        
-        sigmas[0]   = x
-        sigmas[i]   = x - self.s[i  ]*np.sqrt(P)
-        sigmas[i+n] = x + self.s[i+1]*np.sqrt(P)
-        
-        return sigmas
     
     def _redefine_scale_param(self, sigmas, x, P):
-        for i in range(2*self.n+1):
-            sigma_point = sigmas[i]
-    
-            if sigma_point < 0:
+        for i in range(len(sigmas)):
+            if sigmas[i] < 0:
                 self.s[i] = self.k*np.min(x/np.sqrt(P))
         
     def __repr__(self):

--- a/filterpy/kalman/sigma_points.py
+++ b/filterpy/kalman/sigma_points.py
@@ -654,8 +654,11 @@ class GeneralizedSigmaPoints(object):
         else:
             P = np.atleast_2d(P)
         
-        # NOTE: add warning when x is different.
-        
+        if x != self.x:
+            raise Warning(f"input x is different from previous data. \n-initial: {self.x} \n-input  : {x}")
+        if x != self.x:
+            raise Warning(f"input P is different from previous data. \n-initial: {self.P} \n-input  : {P}")
+            
         sigmas = np.zeros((2*n+1, n))
         for i in range(1, self.n+1):
             i_=i-1

--- a/filterpy/kalman/sigma_points.py
+++ b/filterpy/kalman/sigma_points.py
@@ -534,6 +534,46 @@ class SimplexSigmaPoints(object):
             ])
 
 class EbeigbeSigmaPoints(object):
+    '''
+    Generates sigma points and weights according to the generalized unscented
+    transformation method presented in [1]. It utilizes the first four 
+    statistical moments to generate the sigma points and their weights for 
+    most of probability distributions.
+    
+    
+    Parameters
+    ----------
+
+    n : int
+        Dimensionality of the state. n+1 weights will be generated.
+    P : scalar, or np.array
+        Covariance of the filter. If scalar, is treated as eye(n)*P.
+    S : scalar, or np.array
+        third central moment, skewness
+    K : scalar, or np.array
+        fourth central moment, kurtosis
+    positively_constrained : bool
+        enable positively constrained sigma points. It recompute the weights 
+        and scales parameters in order to avoid negative sigmas points. Useful
+        for function that does not accept negative values, although it is only 
+        only accurate up to third order.
+        It redifines the scale parameter 's[i]' and consequently 's[i+n]' and
+        weights.
+    k : float
+        slack parameter. Where value k=1 ensures that at least one of the 
+        sigma points is zero. The sigma points gets futher away from zero as
+        k->0.
+    x : An array-like object of the means of length n
+        used for sigmas points recalculation when 'positively_constrained' is 
+        True. 
+        
+    References
+    ----------
+    
+    .. [1] Donald Ebeigbe et al. "Generalized Unscented Transformation for 
+           Probability Distributions"
+           arXiv:2104.01958v1 [stat.ME]
+    '''
     def __init__(self, n, P, S, K, positively_constrained=False, k=None, x=None):
         self.n = n
         
@@ -548,11 +588,42 @@ class EbeigbeSigmaPoints(object):
         self.s = np.zeros(2*self.n+1)
         
         self._compute_weights()
+        if positively_constrained:
+            self.sigma_points(x, P)
         
     def num_sigmas(self):
+        """ Number of sigma points for each variable in the state x"""
         return 2*self.n + 1
     
     def sigma_points(self, x, P):
+        """
+        Computes the implex sigma points for an unscented Kalman filter
+        given the mean (x) and covariance(P) of the filter.
+        Returns tuple of the sigma points and weights.
+
+        Works with both scalar and array inputs:
+        sigma_points (5, 9, 2) # mean 5, covariance 9
+        sigma_points ([5, 2], 9*eye(2), 2) # means 5 and 2, covariance 9I
+
+        Parameters
+        ----------
+
+        x : An array-like object of the means of length n
+            Can be a scalar if 1D.
+            examples: 1, [1,2], np.array([1,2])
+
+        P : scalar, or np.array
+           Covariance of the filter. If scalar, is treated as eye(n)*P.
+
+        Returns
+        -------
+
+        sigmas : np.array, of size (n, n+1)
+            Two dimensional array of sigma points. Each column contains all of
+            the sigmas for one dimension in the problem space.
+
+            Ordered by Xi_0, Xi_{1..n}
+        """
               
         n = self.n
         
@@ -574,6 +645,16 @@ class EbeigbeSigmaPoints(object):
         return sigmas
     
     def _compute_weights(self, compute_free_parameter=True):
+        """ 
+        Computes the weights and scale parameters for the scaled unscented 
+        Kalman filter. 
+        
+        Parameters
+        ----------
+        
+        compute_free_parameter : bool
+            compute the free parameter s[i] for partially match kurtosis
+        """
         
         n = self.n
         
@@ -599,18 +680,31 @@ class EbeigbeSigmaPoints(object):
         self.Wc = w
         
     
-    def _redefine_scale_param(self, sigmas, x, P):
+    def _redefine_scale_param(self, sigmas):
+        """
+        Evaluate and redifine all negative sigma points
+
+        Parameters
+        ----------
+        sigmas : np.array
+            sigma points.
+
+        """
         for i in range(len(sigmas)):
             if sigmas[i] < 0:
-                self.s[i] = self.k*np.min(x/np.sqrt(P))
+                self.s[i] = self.k*np.min(self.x/np.sqrt(self.P))
         
     def __repr__(self):
         return '\n'.join([
             'EbeigbeSigmaPoints object',
             pretty_str('n', self.n),
-            pretty_str('s', self.s),
-            pretty_str('Wm', self.Wm),
-            pretty_str('Wc', self.Wc),
+            pretty_str('x', self.x),
+            pretty_str('P', self.P),
+            pretty_str('S', self.S),
+            pretty_str('K', self.K),
             pretty_str('Positively constrained', self.positively_constrained),
             pretty_str('k', self.k),
+            pretty_str('Wm', self.Wm),
+            pretty_str('Wc', self.Wc),
+            
             ])

--- a/filterpy/kalman/sigma_points.py
+++ b/filterpy/kalman/sigma_points.py
@@ -581,7 +581,7 @@ class GeneralizedSigmaPoints(object):
         if x is not None:
             if np.isscalar(x):
                 x = np.asarray([x])
-            x = x.reshape(-1, 1)
+            # x = x.reshape(-1, 1)
 
         if np.isscalar(P):
             P = np.eye(n) * P
@@ -723,8 +723,9 @@ class GeneralizedSigmaPoints(object):
 
         """
         for i in range(len(sigmas)):
-            if sigmas[i] < 0:
-                self.s[i] = self.k*np.min(self.x/np.sqrt(self.P))
+            i_=i-1
+            if np.min(sigmas[i]) < 0:
+                self.s[i] = self.k*np.min(self.x/np.sqrt(self.P)[:, i_])
         
     def __repr__(self):
         return '\n'.join([


### PR DESCRIPTION
# Implemented Generalized sigma-points 

Source: 
- A Generalized Unscented Transformation for Probability Distributions
  Donald Ebeigbe, Tyrus Berry, Michael M. Norton, Andrew J. Whalen, Dan Simon, Timothy Sauer, and Steven J. Schiff
  arXiv:2104.01958v1 [stat.ME] 5 Apr 2021
  https://arxiv.org/pdf/2104.01958.pdf

This is a part of my research. I am investigating continuous representation for structural reliability, that usually is a exponential distribution. So, this method partially solve my problem, because it estimates quite accurately the first 4 statistical moments of most distributions. Perhaps it is interesting to have it in _filterpy_.

Soon, I will test it for UKF and push it into tests, but for some rapid tests I did here, it work pretty well.

Where were basically two modifications:
1. In _sigma_points.py_, added a class **GeneralizedSigmaPoints**.
2. In _test/test_ukf.py_, added three tests for this method:  **test_generalized_sigma_points_weights_1D**, **test_generalized_sigma_points_2D**, and **test_generalized_sigma_points_2D_positively_constrained**. These tests are reproductions of papers examples.

Note that is necessary for this method the use of the first 4 moments. So far, you have to add _x_ and _P_ twice, first in the class initialization and then in _sigma_points_ function. It has a warning when the values are different. Perhaps it is better to exclude the inputs in _sigma_points_ function. 

This library helped me a lot to understand Kalman Filters, so I would like to contribute somehow.