### PR TITLE
Fix requirements.txt syntax

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pip install numpy
-pip install scipy
+numpy
+scipy


### PR DESCRIPTION
This commit fixes the syntax of the requirements.txt file which currently incorrectly includes `pip install` ahead of each package name.