### PR TITLE
Permit Jacobian function to also return h(x)

### DIFF
--- a/filterpy/kalman/EKF.py
+++ b/filterpy/kalman/EKF.py
@@ -315,13 +315,16 @@ class ExtendedKalmanFilter(object):
             z = np.asarray([z], float)
 
         H = HJacobian(self.x, *args)
+        if isinstance(H, tuple):
+            H, hx = H  # then it must be both H and Hx, split them out
+        else:
+            hx = Hx(self.x, *hx_args)
 
         PHT = dot(self.P, H.T)
         self.S = dot(H, PHT) + R
         self.SI = linalg.inv(self.S)
         self.K = PHT.dot(self.SI)
 
-        hx = Hx(self.x, *hx_args)
         self.y = residual(z, hx)
         self.x = self.x + dot(self.K, self.y)
 


### PR DESCRIPTION
Without breaking the existing API, permit the Jacobian function to be a complete "model" function that returns both the Jacobian and h(x).

In complex systems the constructs for h(x) and the Jacobian are often similar.  Separate functions result in duplicate calculations.