### PR TITLE
remove unused compute_log_likelihood parameter in kalman_filter.py

### DIFF
--- a/filterpy/kalman/kalman_filter.py
+++ b/filterpy/kalman/kalman_filter.py
@@ -285,11 +285,6 @@ class KalmanFilter(object):
         size of the control input, if it is being used.
         Default value of 0 indicates it is not used.
 
-    compute_log_likelihood : bool (default = True)
-        Computes log likelihood by default, but this can be a slow
-        computation, so if you never use it you can turn this computation
-        off.
-
     Attributes
     ----------
     x : numpy.array(dim_x, 1)


### PR DESCRIPTION
The `compute_log_likelihood` parameter, listed in the documentation and `kalman_filter.py` docstrings, is not supported, and an Exception is raised if it is invoked when defining a KalmanFilter(). Error reproduced below. 

```
Python 3.8.18 (default, Sep 11 2023, 08:17:33) 
[Clang 14.0.6 ] :: Anaconda, Inc. on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from filterpy.kalman import KalmanFilter
>>> KalmanFilter(dim_x=2,dim_z=1)
KalmanFilter object
dim_x = 2
dim_z = 1
dim_u = 0
x = [[0. 0.]].T
P = [[1. 0.]
     [0. 1.]]
x_prior = [[0. 0.]].T
P_prior = [[1. 0.]
           [0. 1.]]
x_post = [[0. 0.]].T
P_post = [[1. 0.]
          [0. 1.]]
F = [[1. 0.]
     [0. 1.]]
Q = [[1. 0.]
     [0. 1.]]
R = [[1.]]
H = [[0. 0.]]
K = [[0. 0.]].T
y = [[0.]]
S = [[0.]]
SI = [[0.]]
M = [[0.]]
B = None
z = [[None]]
log-likelihood = -708.3964185322641
likelihood = 2.2250738585072014e-308
mahalanobis = 0.0
alpha = 1.0
inv = <function inv at 0x7f7f601f81f0>
>>> 
>>> 
>>> KalmanFilter(dim_x=2,dim_z=1,compute_log_likelihood=False)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() got an unexpected keyword argument 'compute_log_likelihood'
>>> 
```