### PR TITLE
Avoid deprecation warning

### DIFF
--- a/filterpy/common/helpers.py
+++ b/filterpy/common/helpers.py
@@ -387,7 +387,7 @@ def outer_product_sum(A, B=None):
     r"""
     Computes the sum of the outer products of the rows in A and B
 
-        P = \Sum {A[i] B[i].T} for i in 0..N
+        P = \\Sum {A[i] B[i].T} for i in 0..N
 
         Notionally:
 


### PR DESCRIPTION
Hi,

I was just tired of getting the
filterpy/common/helpers.py:364: DeprecationWarning: invalid escape sequence '\S'
warning. I know that since a raw string is used, it should be no issue, but it keeps coming up in my logs. Hence, I changed it. I think this should be fine since it says that the \ is not an escape character for Python but part of the (LaTeX) text.