### PR TITLE
Fixed compatibility filterpy.stats with NumPy 2.2.0

### DIFF
--- a/filterpy/stats/stats.py
+++ b/filterpy/stats/stats.py
@@ -379,8 +379,8 @@ def multivariate_gaussian(x, mu, cov):
          "a future release of FilterPy"), DeprecationWarning)
 
     # force all to numpy.array type, and flatten in case they are vectors
-    x = np.array(x, copy=False, ndmin=1).flatten()
-    mu = np.array(mu, copy=False, ndmin=1).flatten()
+    x = np.asarray(x).flatten()
+    mu = np.asarray(mu).flatten()
 
     nx = len(mu)
     cov = _to_cov(cov, nx)


### PR DESCRIPTION
The function "multivariate_gaussian" raised an error as current implementation of np.array is outdated for the latest NumPy release. Followed instructions of the Numpy error and it was solved.

Python version 3.12.7
NumPy version 2.2.0
FilterPy version 1.4.5

```
ValueError: Unable to avoid copy while creating an array as requested.
If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.
```
