### PR TITLE
Removes deprecated keyword syntax from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.rst
+description_file = README.rst


### PR DESCRIPTION
Replaced `description-file` with `description_file` so that setuptools >= 78.0 will install package.